### PR TITLE
Fix warnings about escaping and use correct single quotes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,12 +12,12 @@ define line($file, $line, $ensure = 'present') {
       }
     }
     uncomment: {
-      exec { "/bin/sed -i -e'/${line}/s/#\+//' ‘${file}’" :
+      exec { "/bin/sed -i -e'/${line}/s/#\\+//' '${file}'" :
         onlyif => "/bin/grep '${line}' '${file}' | /bin/grep '^#' | /usr/bin/wc -l"
       }
     }
     comment: {
-      exec { "/bin/sed -i -e'/${line}/s/\(.\+\)$/#\1/' ‘${file}’" :
+      exec { "/bin/sed -i -e'/${line}/s/\\(.\\+\\)$/#\\1/' '${file}'" :
         onlyif => "/usr/bin/test `/bin/grep '${line}' '${file}' | /bin/grep -v '^#' | /usr/bin/wc -l` -ne 0"
       }
     }


### PR DESCRIPTION
The code as-is caused warnings for me about unrecognised escape sequences. Also, the comment/uncomment commands caused errors due to the strange quote characters used. This is when running on a Debian/Ubuntu system.

This pull request fixes both these issues. I have tested both commenting and uncommenting lines and it now works correctly for me.
